### PR TITLE
Alterações de palavras para melhorar o entedimento do usuário

### DIFF
--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -78,7 +78,7 @@
 							 </tr>
 
 							 <tr>
-							 <td><label class="titleLabels">Lançar horas: </label></td>
+							 <td><label class="titleLabels">Registrar horas: </label></td>
 	  						 <td><div class="mui-textfield mui-textfield--float-label">				  
 	   						 <input type="number" class="input-atividade number" name="task[spentTime]" id="task_spentTime" value="0" min="0">	 
 	  						 </div></td>

--- a/app/views/tasks/relatorios.html.erb
+++ b/app/views/tasks/relatorios.html.erb
@@ -43,7 +43,7 @@
 
 	            <div class="col-md-4 historico-semana-atual">
 	            <h5 class="subTitle-relatorios">Semana Atual</h5>
-	            <p class="text-relatorios">Total de horas investidas nesta semana: <b>
+	            <p class="text-relatorios">Total de horas registradas nesta semana: <b>
 	            <% @totalWeek1.each do |tw1| -%>
 	            <%= tw1.total %>
 	            <%end%>	


### PR DESCRIPTION
Considerei necessário alterar os termos relacionados com o verbo "Lançar" porque, como usuário, considero isso menos ambíguo.